### PR TITLE
remove prepending "\" if no domain is used

### DIFF
--- a/3PAR-Powershell/Public/Connect-3PAR.ps1
+++ b/3PAR-Powershell/Public/Connect-3PAR.ps1
@@ -49,6 +49,12 @@ Function Connect-3PAR {
       user=$Credentials.username;
       password=$Credentials.GetNetworkCredential().Password
     }
+
+    if($body['user'].SubString(0,1) -eq '\') {
+        Write-Verbose -Message 'Remove prepending "\" from username for authentification'
+        $body['user']=$body['user'].SubString(1)
+    }
+
     $headers = @{}
     $headers["Accept"] = "application/json"
 


### PR DESCRIPTION
if "plain" user login is used (without a domain) it fails due to prepending "\" from "Get-Credential"